### PR TITLE
Implementing processing of init events

### DIFF
--- a/src/main/java/de/creative_land/clonkspot/SseListener.java
+++ b/src/main/java/de/creative_land/clonkspot/SseListener.java
@@ -29,15 +29,10 @@ import okhttp3.Response;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @RequiredArgsConstructor
 public class SseListener implements ServerSentEvent.Listener {
-
-    private final ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 5, 2, TimeUnit.MINUTES, new ArrayBlockingQueue<>(50));
 
     int errorCounter = 0;
     private final WatchDog watchDog;
@@ -67,7 +62,7 @@ public class SseListener implements ServerSentEvent.Listener {
     public void onMessage(ServerSentEvent sse, String id, String event, String message) {
         watchDog.feed();
         try {
-            executor.execute(() -> DiscordConnector.INSTANCE.gameDispatcher.process(message, event));
+            DiscordConnector.INSTANCE.gameDispatcher.process(message, event);
         } catch (Exception e) {
             Controller.INSTANCE.log.addLogEntry(e);
         }

--- a/src/main/java/de/creative_land/clonkspot/model/GameRefEvent.java
+++ b/src/main/java/de/creative_land/clonkspot/model/GameRefEvent.java
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+// This file is part of the Clonkspot-Connector - https://github.com/Somebodyisnobody/Clonkspot-Connector
+//
+// Clonkspot-Connector is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Clonkspot-Connector is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Clonkspot-Connector.  If not, see <http://www.gnu.org/licenses/>.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+package de.creative_land.clonkspot.model;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class GameRefEvent {
+    @NonNull
+    private final GameReference gameReference;
+
+    @NonNull
+    private final EventType eventType;
+
+    public enum EventType {
+        CREATE("create"),
+        UPDATE("update"),
+        LOBBY_CLOSED("delete"),
+        GAME_ENDED("end"),
+        UNKNOWN_ENDED_OR_CLOSED(null),
+        ;
+
+        private final String value;
+
+        EventType(String value) {
+            this.value = value;
+        }
+
+        /**
+         * Returns the enum constant of this type with the specified value.
+         * The string must match exactly a value used to declare an enum constant in this type.
+         *
+         * @param value The value of the enum constant.
+         * @return The enum constant with the specified value.
+         */
+        public static EventType fromValue(@NonNull String value) {
+            for (EventType b : EventType.values()) {
+                if (b.value.equals(value)) {
+                    return b;
+                }
+            }
+            throw new IllegalArgumentException("Unexpected value '" + value + "'");
+        }
+
+        @Override
+        public String toString() {
+            return String.valueOf(value);
+        }
+    }
+}

--- a/src/main/java/de/creative_land/clonkspot/model/GameReference.java
+++ b/src/main/java/de/creative_land/clonkspot/model/GameReference.java
@@ -19,11 +19,13 @@
 package de.creative_land.clonkspot.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 
 @SuppressWarnings("unused")
+@Getter
 public class GameReference {
 
-    final public int id;
+    final public Integer id;
 
     final public String title;
 
@@ -33,7 +35,7 @@ public class GameReference {
 
     final public String comment;
 
-    final public int maxPlayers;
+    final public Integer maxPlayers;
 
     final public String hostname;
 
@@ -43,15 +45,13 @@ public class GameReference {
 
     final public String engine;
 
-    final public int engineBuild;
+    final public Integer engineBuild;
 
     final public Player[] players;
 
     final public Flags flags;
 
     final public Scenario scenario;
-
-    public String sseEventType;
 
     public GameReference(@JsonProperty("id") int id, @JsonProperty("title") String title, @JsonProperty("status") String status,
                          @JsonProperty("type") String league, @JsonProperty("comment") String comment, @JsonProperty("maxPlayers") int maxPlayers,

--- a/src/main/java/de/creative_land/discord/clonk_game_reference/Dispatcher.java
+++ b/src/main/java/de/creative_land/discord/clonk_game_reference/Dispatcher.java
@@ -65,17 +65,22 @@ public class Dispatcher {
 
         if (event.equals("init")) {
             processInitEvent(message);
-            return;
-        } else if (event.equals("create") || event.equals("update") || event.equals("delete") || event.equals("end")) {
+        } else {
             final GameReference gameReference;
             if ((gameReference = parseGameReference(message)) == null) return;
-            final GameRefEvent gameRefEvent = new GameRefEvent(gameReference, GameRefEvent.EventType.fromValue(event));
+
+            GameRefEvent.EventType eventType;
+            try {
+                eventType = GameRefEvent.EventType.fromValue(event);
+            } catch (IllegalArgumentException e) {
+                Controller.INSTANCE.log.addLogEntry("DiscordConnector: Unknown event received: '%s'".formatted(event));
+                return;
+            }
+
+            final GameRefEvent gameRefEvent = new GameRefEvent(gameReference, eventType);
 
             executor.execute(() -> routeGameRefEvent(gameRefEvent));
-            return;
         }
-        // Ignore all other event types
-        Controller.INSTANCE.log.addLogEntry("DiscordConnector: Unknown event received: '%s'".formatted(event));
     }
 
     /**

--- a/src/main/java/de/creative_land/discord/clonk_game_reference/Dispatcher.java
+++ b/src/main/java/de/creative_land/discord/clonk_game_reference/Dispatcher.java
@@ -59,7 +59,6 @@ public class Dispatcher {
      * @param message SSE message
      * @param event   SSE event
      */
-    //
     public synchronized void process(@NotNull String message, @NotNull String event) {
         if (!Objects.equals(DiscordConnector.INSTANCE.status.getCurrentOnlineStatus(), OnlineStatus.ONLINE)) return;
 
@@ -202,7 +201,10 @@ public class Dispatcher {
      */
     private boolean announceNewGameReference(GameReference gameReference, AnnounceReason announceReason) {
         //Never announce if the bot status is not RUNNING
-        if (!isRunning()) return false;
+        if (!canDispatch()) return false;
+
+        //Only announce games that are newly created or in the lobby. Already existing announcements for other games may only be edited.
+        if (!gameReference.getStatus().equals("created") && !gameReference.getStatus().equals("lobby")) return false;
 
         //Only announce games with a specific host engine version
         if (!isTargetVersion(gameReference))
@@ -257,7 +259,7 @@ public class Dispatcher {
      *
      * @return true, if the bot is in status "RUNNING".
      */
-    private boolean isRunning() {
+    private boolean canDispatch() {
         return Objects.equals(DiscordConnector.INSTANCE.status.getCurrentActivity(), de.creative_land.discord.Activity.RUNNING);
     }
 

--- a/src/main/java/de/creative_land/discord/clonk_game_reference/Dispatcher.java
+++ b/src/main/java/de/creative_land/discord/clonk_game_reference/Dispatcher.java
@@ -21,23 +21,30 @@ package de.creative_land.discord.clonk_game_reference;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import de.creative_land.Controller;
+import de.creative_land.clonkspot.model.GameRefEvent;
 import de.creative_land.clonkspot.model.GameReference;
 import de.creative_land.discord.DiscordConnector;
+import lombok.Getter;
+import lombok.NonNull;
 import net.dv8tion.jda.api.OnlineStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Objects;
+import java.util.*;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class Dispatcher {
 
     private final MessageBuilder messageBuilder;
+    @Getter
     private final ArrayList<DispatchedMessage> dispatchedMessages;
     private final HashSet<Integer> processedGamesList;
+    private final ThreadPoolExecutor executor = new ThreadPoolExecutor(1, 5, 2, TimeUnit.MINUTES, new ArrayBlockingQueue<>(50));
 
     public Dispatcher() {
         this.messageBuilder = new MessageBuilder();
@@ -46,19 +53,82 @@ public class Dispatcher {
     }
 
     /**
-     * Processes a game reference as SSE event. If it matches the conditions an announcing message will be sent to discord.
+     * Processes a game reference as SSE event. If it matches the conditions an announcing message will be sent to discord. <br/>
+     * Synchronized as no init messages should be processed in parallel.
      *
      * @param message SSE message
      * @param event   SSE event
      */
-    public void process(@NotNull String message, @NotNull String event) {
+    //
+    public synchronized void process(@NotNull String message, @NotNull String event) {
         if (!Objects.equals(DiscordConnector.INSTANCE.status.getCurrentOnlineStatus(), OnlineStatus.ONLINE)) return;
-        if (!(event.equals("create") || event.equals("update") || event.equals("delete") || event.equals("end")))
-            return;
 
-        final GameReference gameReference;
-        if ((gameReference = parseJson(message)) == null) return;
-        gameReference.sseEventType = event;
+        if (event.equals("init")) {
+            processInitEvent(message);
+            return;
+        } else if (event.equals("create") || event.equals("update") || event.equals("delete") || event.equals("end")) {
+            final GameReference gameReference;
+            if ((gameReference = parseGameReference(message)) == null) return;
+            final GameRefEvent gameRefEvent = new GameRefEvent(gameReference, GameRefEvent.EventType.fromValue(event));
+
+            executor.execute(() -> routeGameRefEvent(gameRefEvent));
+            return;
+        }
+        // Ignore all other event types
+        Controller.INSTANCE.log.addLogEntry("DiscordConnector: Unknown event received: '%s'".formatted(event));
+    }
+
+    /**
+     * Processes an init SSE event. New games will be determined, ended games will be marked as such.
+     *
+     * @param message SSE message
+     */
+    public void processInitEvent(@NotNull String message) {
+        List<GameReference> gameReferences = parseGameReferenceList(message);
+        if (gameReferences.isEmpty()) return;
+
+        gameReferences.stream()
+                .filter(
+                        // All game references that are in the init message but not in the list of dispatched messages are new and to be processed as created
+                        gameReference -> dispatchedMessages.stream()
+                                .map(DispatchedMessage::getGameReference)
+                                .map(GameReference::getId)
+                                .noneMatch(id -> id.equals(gameReference.getId()))
+                )
+                .map(gameReference -> new GameRefEvent(gameReference, GameRefEvent.EventType.CREATE))
+                .forEach(this::routeGameRefEvent);
+
+        // All dispatched messages whose game references are not in the init message are old games which have ended in an unkonwn way.
+        // Possible endings (💥 = SSE connection interrupt)
+        // * Game was running -> 💥 -> game ended -> init event                  -> game ended
+        // * Game was in lobby -> 💥 -> lobby closed -> init event               -> unknown status
+        // * Game was in lobby -> 💥 -> game started -> game ended -> init event -> unknown status
+        dispatchedMessages.stream()
+                .filter(dispatchedMessage -> !dispatchedMessage.getDeleted())
+                .map(DispatchedMessage::getGameReference)
+                .filter(
+                        gameReference -> gameReferences.stream()
+                                .map(GameReference::getId)
+                                .noneMatch(id -> id.equals(gameReference.getId()))
+                )
+                .map(lastKnownGameReference -> {
+                    if (lastKnownGameReference.getStatus().equals("running")) {
+                        return new GameRefEvent(lastKnownGameReference, GameRefEvent.EventType.GAME_ENDED);
+                    } else {
+                        // All references whoose last known status was not "running" have an unknown reason for not existing anymore.
+                        return new GameRefEvent(lastKnownGameReference, GameRefEvent.EventType.UNKNOWN_ENDED_OR_CLOSED);
+                    }
+                })
+                .forEach(this::routeGameRefEvent);
+    }
+
+    /**
+     * Decides which action is to be performed out based on the event type.
+     *
+     * @param gameRefEvent The game reference event
+     */
+    private void routeGameRefEvent(@NotNull GameRefEvent gameRefEvent) {
+        final GameReference gameReference = gameRefEvent.getGameReference();
 
         synchronized (processedGamesList) {
             while (processedGamesList.contains(gameReference.id)) {
@@ -70,11 +140,11 @@ public class Dispatcher {
             processedGamesList.add(gameReference.id);
         }
 
-        switch (event) {
-            case "create" -> createEvent(gameReference);
-            case "update" -> updateEvent(gameReference);
-            case "delete" -> deleteEvent(gameReference); //nicht gestartetes game beendet
-            case "end" -> endEvent(gameReference);    //gestartetes game zu ende
+        switch (gameRefEvent.getEventType()) {
+            case CREATE -> createEvent(gameReference);
+            case UPDATE -> updateEvent(gameReference);
+            case LOBBY_CLOSED -> deleteEvent(gameReference); //nicht gestartetes game beendet
+            case GAME_ENDED, UNKNOWN_ENDED_OR_CLOSED -> endEvent(gameReference);    //gestartetes game zu ende
         }
 
         synchronized (processedGamesList) {
@@ -85,7 +155,7 @@ public class Dispatcher {
 
     //START EVENTS//
     private void createEvent(GameReference gameReference) {
-        announceNewGameReference(gameReference);
+        announceNewGameReference(gameReference, AnnounceReason.NEW);
     }
 
     @SuppressWarnings("UnnecessaryReturnStatement")
@@ -93,7 +163,7 @@ public class Dispatcher {
         if (gameReference.status.equals("lobby")) {
 
             //Announce a game if it was not announced by cooldown and the cooldown is over
-            if (announceNewGameReference(gameReference)) return;
+            if (announceNewGameReference(gameReference, AnnounceReason.UPDATE)) return;
 
         } else if (gameReference.status.equals("running")) {
 
@@ -122,14 +192,15 @@ public class Dispatcher {
      * Sends a new message to discord. On success the game is added to a {@link DispatchedMessage} list to avoid double announcing. On fail a rescan of the environment is called.
      *
      * @param gameReference parsed game reference.
+     * @param announceReason reason why the game is to be announced.
      * @return true if the game reference was handled, false if it was rejected.
      */
-    private boolean announceNewGameReference(GameReference gameReference) {
+    private boolean announceNewGameReference(GameReference gameReference, AnnounceReason announceReason) {
         //Never announce if the bot status is not RUNNING
         if (!isRunning()) return false;
 
         //Only announce games with a specific host engine version
-        if (!isCorrectVersion(gameReference))
+        if (!isTargetVersion(gameReference))
             return false;
 
         //Never announce an already announced game (checked by game id)
@@ -138,7 +209,7 @@ public class Dispatcher {
         //Never announce ignored hosts exempt they have active players
         if (isIgnoredHost(gameReference)) {
             //Only log if it's a new game to avoid log spam
-            if (gameReference.sseEventType.equals("create"))
+            if (announceReason == AnnounceReason.NEW)
                 Controller.INSTANCE.log.addLogEntry("DiscordConnector: Ignored by hostname: " + gameReference.id + ", Host: \"" + gameReference.hostname + "\".");
             return false;
         }
@@ -146,7 +217,7 @@ public class Dispatcher {
         //Never announce hosts with active cooldown (checked by hostname)
         if (hostHasActiveCooldown(gameReference)) {
             //Only log if it's a new game to avoid log spam
-            if (gameReference.sseEventType.equals("create"))
+            if (announceReason == AnnounceReason.NEW)
                 Controller.INSTANCE.log.addLogEntry("DiscordConnector: Ignored by cooldown: " + gameReference.id + ", Host: \"" + gameReference.hostname + "\".");
             return false;
         }
@@ -154,7 +225,7 @@ public class Dispatcher {
         //Never announce password protected games
         if (gameReference.flags.passwordNeeded) {
             //Only log if it's a new game to avoid log spam
-            if (gameReference.sseEventType.equals("create"))
+            if (announceReason == AnnounceReason.NEW)
                 Controller.INSTANCE.log.addLogEntry("DiscordConnector: Ignored by password: " + gameReference.id + ", Host: \"" + gameReference.hostname + "\".");
             return false;
         }
@@ -191,7 +262,7 @@ public class Dispatcher {
      * @param gameReference parsed game reference.
      * @return true if the game reference has the correct version, false if not.
      */
-    private boolean isCorrectVersion(GameReference gameReference) {
+    private boolean isTargetVersion(GameReference gameReference) {
         final var engine = Controller.INSTANCE.configuration.getEngine();
         final var engineBuild = Controller.INSTANCE.configuration.getEngineBuild();
 
@@ -214,7 +285,7 @@ public class Dispatcher {
 
         //Filter out the references that belongs to the game and allowed runtime join or was in status lobby before
         final var optionalDispatchedMessage = dispatchedMessages.stream()
-                .filter(dispatchedMessage -> dispatchedMessage.getGameReference().id == gameReference.id)
+                .filter(dispatchedMessage -> dispatchedMessage.getGameReference().id.equals(gameReference.id))
                 .filter(dispatchedMessage -> !dispatchedMessage.getDeleted())
                 .filter(dispatchedMessage -> dispatchedMessage.getGameReference().flags.joinAllowed || dispatchedMessage.getGameReference().status.equals("created"))
                 .findFirst();
@@ -239,7 +310,7 @@ public class Dispatcher {
 
         //Filter out the reference that belongs to the game and denied runtime join or was in status lobby before
         final var optionalDispatchedMessage = dispatchedMessages.stream()
-                .filter(dispatchedMessage -> dispatchedMessage.getGameReference().id == gameReference.id)
+                .filter(dispatchedMessage -> dispatchedMessage.getGameReference().id.equals(gameReference.id))
                 .filter(dispatchedMessage -> !dispatchedMessage.getDeleted())
                 .filter(dispatchedMessage -> !dispatchedMessage.getGameReference().flags.joinAllowed || dispatchedMessage.getGameReference().status.equals("created"))
                 .findFirst();
@@ -261,7 +332,7 @@ public class Dispatcher {
 
         //Search for game reference id and replace
         final var optionalDispatchedMessage = dispatchedMessages.stream()
-                .filter(dispatchedMessage -> dispatchedMessage.getGameReference().id == gameReference.id)
+                .filter(dispatchedMessage -> dispatchedMessage.getGameReference().id.equals(gameReference.id))
                 .filter(dispatchedMessage -> !dispatchedMessage.getDeleted())
                 .findFirst();
 
@@ -280,7 +351,7 @@ public class Dispatcher {
     private boolean deleteReference(GameReference gameReference) {
         //Search for game reference id and delete
         final var optionalDispatchedMessage = dispatchedMessages.stream()
-                .filter(dispatchedMessage -> dispatchedMessage.getGameReference().id == gameReference.id)
+                .filter(dispatchedMessage -> dispatchedMessage.getGameReference().id.equals(gameReference.id))
                 .filter(dispatchedMessage -> !dispatchedMessage.getDeleted())
                 .findFirst();
 
@@ -331,7 +402,7 @@ public class Dispatcher {
      * @return true if a game with the same id was announced in earlier.
      */
     private boolean isAlreadyAnnounced(GameReference gameReference) {
-        return dispatchedMessages.stream().anyMatch(dispatchedMessage -> dispatchedMessage.getGameReference().id == gameReference.id);
+        return dispatchedMessages.stream().anyMatch(dispatchedMessage -> dispatchedMessage.getGameReference().id.equals(gameReference.id));
     }
 
     /**
@@ -366,12 +437,12 @@ public class Dispatcher {
     }
 
     /**
-     * Parses a JSON-String of a SSE-event into a {@link GameReference}.
+     * Parses a JSON-String of an SSE-event into a {@link GameReference}.
      *
      * @param message SSE-message in JSON format.
      * @return a {@link GameReference} parsed from the String or null if the message could not be parsed.
      */
-    private GameReference parseJson(String message) {
+    private GameReference parseGameReference(String message) {
         ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         try {
             return mapper.readValue(message, GameReference.class);
@@ -379,6 +450,23 @@ public class Dispatcher {
             Controller.INSTANCE.log.addLogEntry("DiscordConnector: JSON Parsing error: \n", e);
         }
         return null;
+    }
+
+    /**
+     * Parses a JSON-String of an SSE-event into a {@link GameReference} list.
+     *
+     * @param message SSE-message in JSON format.
+     * @return a list of {@link GameReference} parsed from the String or null if the message could not be parsed.
+     */
+    private @NonNull List<GameReference> parseGameReferenceList(String message) {
+        ObjectMapper mapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        TypeFactory typeFactory = mapper.getTypeFactory();
+        try {
+            return mapper.readValue(message, typeFactory.constructCollectionType(List.class, GameReference.class));
+        } catch (JsonProcessingException e) {
+            Controller.INSTANCE.log.addLogEntry("DiscordConnector: JSON Parsing error: \n", e);
+        }
+        return Collections.emptyList();
     }
 
     /**
@@ -393,7 +481,8 @@ public class Dispatcher {
         dispatchedMessages.add(dispatchedMessage);
     }
 
-    public ArrayList<DispatchedMessage> getDispatchedMessages() {
-        return dispatchedMessages;
+    private enum AnnounceReason {
+        NEW,
+        UPDATE
     }
 }


### PR DESCRIPTION
Init events are now processed and the application detects if games were opened or closed meanwhile.

- Moved ThreadPoolExecutor from SseListener to Dispatcher (one level higher in the stack)
- Init events are exclusively processed which blocks other events after the init from being processed until the init event has been processed.
- Refactored the server side event type handling. The determination of the type of event is no longer tied to the SSE event type (server's view). Instead, a functional level has been introduced that makes it possible to set an event type for init messages that considers the client's view. For example game references which are not anymore in the init message will neither be considered as ended or deleted (implicit server's view) but as "ended but unknown how it ended". In the router (routeGameRefEvent()) uses this information to decide how to process the events.
- Never announce running or ended games regardless of the client's view about the status
- Using enums instead of strings
- Use objects instead of primitives (Needed for processing in Streams)
- Some logging optimized

Request for comments.